### PR TITLE
chore: use the tag-name as version number upon release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,6 +60,15 @@ jobs:
       run: |
         cargo install wasm-pack
 
+    - name: Update version to the release version
+      run: |
+        # Remove the "v" from the version.
+        export VERSION=$(echo ${{ github.ref }} | cut -b2-)
+
+        # Use sed for now, as https://github.com/rust-lang/cargo/issues/7722 isn't in stable yet.
+        sed -i 's/version = "0.0.0-git"/version = "'${VERSION}'"/' Cargo.toml
+        sed -i 's/version = "0.0.0-git"/version = "'${VERSION}'"/' Cargo.lock
+
     - name: Create NPM package
       run: |
         wasm-pack build --release --target web

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "truegrf"
-version = "1.0.0"
+version = "0.0.0-git"
 dependencies = [
  "base64",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "truegrf"
-version = "1.0.0"
+version = "0.0.0-git"
 authors = ["Patric Stout <truebrain@openttd.org>"]
 license = "GPL-2.0-only"
 description = "TrueGRF YAML to GRF compiler"


### PR DESCRIPTION
Doing manual bumps is just a recipe for disaster, which will be
forgotten time after time after time. So instead, use some automation
to do that work for us.

Cargo has a feature pending, which allows to override the version
via the CLI. This has landed in nightly, and is approved to go to
stable, but isn't there yet. If that lands, that is a much better
approach for this, as it doesn't actually modify any files (which
are of course error-prune).